### PR TITLE
Changed the heading in Threat Stack integration doc (from 'Datadog' t…

### DIFF
--- a/pages/mydoc/threat_stack.md
+++ b/pages/mydoc/threat_stack.md
@@ -16,7 +16,7 @@ Route detailed events from Threat Stack to the right users in Squadcast.
 
 ## How to integrate Threat Stack with Squadcast
 
-### In Squadcast: Using Datadog as an Alert Source
+### In Squadcast: Using Threat Stack as an Alert Source
 
 **(1)** On the **Sidebar**, click on **Services**.
 


### PR DESCRIPTION
…o 'Threat Stack')

# Description 

What does this pull do ?
Changed the heading in Threat Stack integration doc

## What kind of changes do it do
Modified a title to have the work 'Threat Stack' instead of 'Datadog'

Please delete options that are not relevant.

- [ ] UPDATES ( change which updates an existing doc )

## Roles

**Assignees:** anushasquadcast
**Reviewers:** ShubhanjanMedhi-dev
**Approvers:** ShubhanjanMedhi-dev

## Changelog

add the change log here
