### PR TITLE
Removed Crashlytics from docs and sidebar since alert source is depre…

### DIFF
--- a/_data/sidebars/mydoc_sidebar.yml
+++ b/_data/sidebars/mydoc_sidebar.yml
@@ -299,10 +299,6 @@ entries:
             url: /docs/coralogix
             output: web, pdf
 
-          - title: Crashlytics
-            url: /docs/crashlytics
-            output: web, pdf
-
           - title: Datadog
             url: /docs/datadog
             output: web, pdf

--- a/pages/mydoc/crashlytics.md
+++ b/pages/mydoc/crashlytics.md
@@ -5,6 +5,7 @@ tags: [integration, crashlytics]
 summary: "Send issues to Squadcast from Crashlytics (Fabric SDK)"
 sidebar: mydoc_sidebar
 permalink: docs/crashlytics
+published: false
 ---
 
 Follow the steps below to configure a service so as to get alerts from Crashlytics. Squadcast will then process the incidents for the service as per the users preferences.


### PR DESCRIPTION
…cated

# Description 

What does this pull do ?
Removed Crashlytics from docs and sidebar since alert source is deprecated

Please delete options that are not relevant.

- [ ] UPDATES ( change which updates an existing doc )

## Roles

**Assignees:** @anushasquadcast 
**Reviewers:** @bigeyedandroid @ShubhanjanMedhi-dev 
**Approvers:** @bigeyedandroid @ShubhanjanMedhi-dev 

## Changelog

add the change log here
