### PR TITLE
fix: removed "pro" from microsoft and azure sso

### DIFF
--- a/pages/mydoc/azure_active_directory_sso.md
+++ b/pages/mydoc/azure_active_directory_sso.md
@@ -15,7 +15,7 @@ Squadcast supports SAML 2.0 based  Single Sign On (SSO) login for Azure Active D
 
 1. Account Owner / Administrator account in Squadcast
 
-2. A valid Squadcast subscription ([Pro & Enterprise](https://www.squadcast.com/pricing))
+2. A valid Squadcast subscription ([Enterprise](https://www.squadcast.com/pricing))
 
 {{site.data.alerts.blue-note}}
 <b>Point to Note: </b>

--- a/pages/mydoc/microsoft_adfs_sso.md
+++ b/pages/mydoc/microsoft_adfs_sso.md
@@ -15,7 +15,7 @@ Squadcast supports SAML 2.0 based Single Sign On (SSO) login for Microsoft Activ
 
 1. Account Owner / Administrator account in Squadcast
 
-2. A valid Squadcast subscription ([Pro & Enterprise](https://www.squadcast.com/pricing))
+2. A valid Squadcast subscription ([Enterprise](https://www.squadcast.com/pricing))
 
 {{site.data.alerts.blue-note}}
 <b>Points to Note: </b>


### PR DESCRIPTION
# Description 

What does this pull do ?
removed "pro" from microsoft and azure sso

## What kind of changes do it do

- [x] UPDATES ( change which updates an existing doc )

## Roles

**Assignees:** @SquadcastHelp 
**Reviewers:** @SquadcastHelp @bigeyedandroid @anushasquadcast 
**Approvers:** @SquadcastHelp @bigeyedandroid @anushasquadcast 

## Changelog

removed "pro" from microsoft and azure sso
